### PR TITLE
Add compatibility layer for ittapi Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ import pyitt.compatibility_layers.itt_python as itt
 
 For more details, please see [itt_python_compatibility_sample.py](samples/itt_python_compatibility_sample.py).
 
+### [ittapi](https://github.com/intel/ittapi/)
+
+`pyitt.compatibility_layers.ittapi` implements most of ittapi Python binding public API. Technically, the Python binding
+to ITT API that is included in the ITT API repository is based on the pyitt v1.1.0 code base. But, the implementations
+have been diverging since then. However, in most cases, it should be possible to use newer versions of pyitt instead of
+ittapi just by replacing the imports. For example, the import for ittapi:
+
+```python
+import ittapi
+```
+
+should be replaced with:
+
+```python
+import pyitt.compatibility_layers.ittapi as ittapi
+```
+
 ## Known Issues and Limitations
 
 - If pyitt is used in a function which is specified as a target for calls from 

--- a/pyitt/_named_region.py
+++ b/pyitt/_named_region.py
@@ -109,7 +109,7 @@ class _NamedRegion(_Region):
     def __call_name_determination_callback(self):
         """Calls a name determination callback."""
         if callable(self.__name_determination_callback):
-            self.__name_determination_callback(self.name)
+            self.__name_determination_callback(self.__name)
 
     def __mark_name_as_final(self):
         """Marks the current name as a final name of a code region."""

--- a/pyitt/compatibility_layers/ittapi/__init__.py
+++ b/pyitt/compatibility_layers/ittapi/__init__.py
@@ -1,0 +1,17 @@
+"""
+Compatibility layer for ittapi.
+
+This module provides a compatibility layer that allows to use pyitt as a backend for ittapi Python bindings
+(https://github.com/intel/ittapi/tree/master/python).
+"""
+from pyitt.native import Domain, Id, StringHandle
+from pyitt.native import task_begin, task_end, task_begin_overlapped, task_end_overlapped
+from pyitt.collection_control import detach, pause, resume, active_region, paused_region, ActiveRegion, PausedRegion
+from pyitt.domain import domain
+from pyitt.id import id
+from pyitt.string_handle import string_handle
+from pyitt.thread_naming import thread_set_name
+
+from .event import event, Event
+from .pt_region import pt_region
+from .task import NestedTask, OverlappedTask, task, nested_task, overlapped_task

--- a/pyitt/compatibility_layers/ittapi/event.py
+++ b/pyitt/compatibility_layers/ittapi/event.py
@@ -1,0 +1,28 @@
+from pyitt import Event as _Event
+from pyitt._named_region import _CallSite
+
+
+class Event(_Event):
+    """
+    A class that represents Event.
+    """
+    def __str__(self) -> str:
+        return self.name()
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}('{self.name()}')"
+
+    def name(self):
+        """Gets the name of the event."""
+        return super().name
+
+
+def event(region=None) -> Event:
+    """
+    Creates an Event instance.
+    :param region: a name of the event or a callable object (e.g. function) to wrap. If the callable object is
+                   passed the name of this object is used as a name for the event.
+    :return: an Event instance
+    """
+    region = _CallSite(_CallSite.CallerFrame) if region is None else region
+    return Event(region)

--- a/pyitt/compatibility_layers/ittapi/pt_region.py
+++ b/pyitt/compatibility_layers/ittapi/pt_region.py
@@ -1,0 +1,34 @@
+from pyitt import PTRegion as _PTRegion
+from pyitt._named_region import _CallSite
+
+
+class PTRegion(_PTRegion):
+    """
+    A class that represents PT region.
+
+    It provides control over collection of Intel Processor Trace (Intel PT) data.
+    """
+    def __str__(self) -> str:
+        return self.name()
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}('{self.name()}')"
+
+    def name(self):
+        """Gets the name of the PT region."""
+        return super().name
+
+    def get_pt_region(self):
+        """Gets the PT region."""
+        return self
+
+
+def pt_region(region=None) -> PTRegion:
+    """
+    Creates a PT region instance.
+    :param region: a name of the region or a callable object (e.g. function) to wrap. If the callable object is
+                   passed the name of this object is used as a name for the region.
+    :return: a PT region instance
+    """
+    region = _CallSite(_CallSite.CallerFrame) if region is None else region
+    return PTRegion(region)

--- a/pyitt/compatibility_layers/ittapi/task.py
+++ b/pyitt/compatibility_layers/ittapi/task.py
@@ -1,0 +1,107 @@
+from pyitt import task_begin as _task_begin, task_end as _task_end
+from pyitt import task_begin_overlapped as _task_begin_overlapped, task_end_overlapped as _task_end_overlapped
+
+from pyitt.task import _Task
+from pyitt._named_region import _CallSite
+
+
+class _CompatibleTask(_Task):
+    """
+    An abstract base class that provides common functionality for subtypes that represent ITT Tasks.
+    """
+
+    def __str__(self) -> str:
+        return (f"{{ name: '{str(self.name())}', domain: '{str(self.domain())}',"
+                f" id: {str(self.id())}, parent_id: {str(self.parent_id())} }}")
+
+    def __repr__(self) -> str:
+        return (f'{self.__class__.__name__}({repr(self.name())}, {repr(self.domain())},'
+                f' {repr(self.id())}, {repr(self.parent_id())})')
+
+    def domain(self):
+        """Gets the domain of the task."""
+        return super().domain
+
+    def name(self):
+        """Gets the name of the task."""
+        return super().name
+
+    def id(self):
+        """Gets the id of the task."""
+        return super().id
+
+    def parent_id(self):
+        """Gets the parent id for the task."""
+        return super().parent_id
+
+
+class NestedTask(_CompatibleTask):
+    """
+    A class that represents nested tasks.
+
+    Nested tasks implicitly support a concept of embedded execution. This means that the call end() finalizes the
+    most recent begin() call of the same or another nested task.
+    """
+    def begin(self) -> None:
+        """Marks the beginning of a task."""
+        _task_begin(self.domain(), self.name(), self.id(), self.parent_id())
+
+    def end(self) -> None:
+        """Marks the end of a task."""
+        _task_end(self.domain())
+
+
+def nested_task(task=None, domain=None, id=None, parent=None):
+    """
+    Creates a nested task instance with the given arguments.
+    :param task: a name of the task or a callable object
+    :param domain: a task domain
+    :param id: a task id
+    :param parent: a parent task or an id of the parent
+    :return: an instance of NestedTask
+    """
+    task = _CallSite(_CallSite.CallerFrame) if task is None else task
+    return NestedTask(task, domain, id, parent)
+
+
+class OverlappedTask(_CompatibleTask):
+    """
+    A class that represents overlapped tasks.
+
+    Execution regions of overlapped tasks may intersect.
+    """
+    def begin(self) -> None:
+        """Marks the beginning of a task."""
+        _task_begin_overlapped(self.domain(), self.name(), self.id(), self.parent_id())
+
+    def end(self) -> None:
+        """Marks the end of a task."""
+        _task_end_overlapped(self.domain(), self.id())
+
+
+def overlapped_task(task=None, domain=None, id=None, parent=None):
+    """
+    Creates an overlapped task instance with the given arguments.
+    :param task: a name of the task or a callable object
+    :param domain: a task domain
+    :param id: a task id
+    :param parent: a parent task or an id of the parent
+    :return: an instance of OverlappedTask
+    """
+    task = _CallSite(_CallSite.CallerFrame) if task is None else task
+    return OverlappedTask(task, domain, id, parent)
+
+
+def task(task=None, domain=None, id=None, parent=None, overlapped=False):
+    """
+    Creates a task instance with the given arguments.
+    :param task: a name of the task or a callable object
+    :param domain: a task domain
+    :param id: a task id
+    :param parent: a parent task or an id of the parent
+    :param overlapped: determines if the created task should be an instance of OverlappedTask class
+                       or NestedTask class
+    :return: a task instance
+    """
+    task = _CallSite(_CallSite.CallerFrame) if task is None else task
+    return OverlappedTask(task, domain, id, parent) if overlapped else NestedTask(task, domain, id, parent)

--- a/tests/unit/compatibility_layers/ittapi/__init__.py
+++ b/tests/unit/compatibility_layers/ittapi/__init__.py
@@ -1,0 +1,3 @@
+"""
+A set of unit tests for ittapi compatibility layer.
+"""

--- a/tests/unit/compatibility_layers/ittapi/test_colection_control.py
+++ b/tests/unit/compatibility_layers/ittapi/test_colection_control.py
@@ -1,0 +1,41 @@
+from unittest import main as unittest_main, TestCase
+
+# pylint: disable=C0411
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt
+import pyitt.compatibility_layers.ittapi as ittapi
+
+
+class DirectCollectionControlTests(TestCase):
+    @pyitt_native_patch('detach')
+    def test_detach_call(self, detach_mock):
+        ittapi.detach()
+        detach_mock.assert_called_once()
+
+    @pyitt_native_patch('pause')
+    def test_pause_call(self, pause_mock):
+        ittapi.pause()
+        pause_mock.assert_called_once()
+
+    @pyitt_native_patch('resume')
+    def test_resume_call(self, resume_mock):
+        ittapi.resume()
+        resume_mock.assert_called_once()
+
+
+class CompatibleCallsTests(TestCase):
+    def test_active_region_call_is_same(self):
+        self.assertIs(ittapi.active_region, pyitt.active_region)
+
+    def test_paused_region_call_is_same(self):
+        self.assertIs(ittapi.paused_region, pyitt.paused_region)
+
+    def test_active_region_class_is_same(self):
+        self.assertIs(ittapi.ActiveRegion, pyitt.ActiveRegion)
+
+    def test_paused_region_class_is_same(self):
+        self.assertIs(ittapi.PausedRegion, pyitt.PausedRegion)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_domain.py
+++ b/tests/unit/compatibility_layers/ittapi/test_domain.py
@@ -1,0 +1,32 @@
+from unittest import main as unittest_main, TestCase
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class DomainTests(TestCase):
+    @pyitt_native_patch('Domain')
+    def test_domain_call_without_arguments(self, domain_class_mock):
+        ittapi.domain()
+        domain_class_mock.assert_called_once_with(None)
+
+    @pyitt_native_patch('Domain')
+    def test_domain_call_with_name(self, domain_class_mock):
+        name = 'my domain'
+        ittapi.domain(name)
+        domain_class_mock.assert_called_once_with(name)
+
+    @pyitt_native_patch('Domain')
+    def test_domain_creation_without_arguments(self, domain_class_mock):
+        ittapi.Domain()
+        domain_class_mock.assert_called_once_with()
+
+    @pyitt_native_patch('Domain')
+    def test_domain_creation_with_name(self, domain_class_mock):
+        name = 'my domain'
+        ittapi.Domain(name)
+        domain_class_mock.assert_called_once_with(name)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_event.py
+++ b/tests/unit/compatibility_layers/ittapi/test_event.py
@@ -1,0 +1,104 @@
+from inspect import stack
+from os.path import basename
+from unittest import main as unittest_main, TestCase
+from unittest.mock import call
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class EventCreationTests(TestCase):
+    @pyitt_native_patch('Event')
+    @pyitt_native_patch('StringHandle')
+    def test_event_creation_with_default_constructor(self, event_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        event = ittapi.event()
+        caller = stack()[0]
+        expected_name = f'{basename(caller.filename)}:{caller.lineno-1}'
+
+        event_class_mock.assert_not_called()
+
+        event.begin()
+
+        event_class_mock.assert_called_once_with(expected_name)
+        self.assertEqual(event.name(), expected_name)
+
+    @pyitt_native_patch('Event')
+    @pyitt_native_patch('StringHandle')
+    def test_event_creation_as_decorator_for_function(self, event_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        @ittapi.event
+        def my_function():
+            pass  # pragma: no cover
+
+        event_class_mock.assert_called_once_with(my_function.__qualname__)
+
+    @pyitt_native_patch('Event')
+    @pyitt_native_patch('StringHandle')
+    def test_event_creation_as_decorator_with_name_for_function(self, event_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        @ittapi.event('my function')
+        def my_function():
+            pass  # pragma: no cover
+
+        event_class_mock.assert_called_once_with('my function')
+
+    @pyitt_native_patch('Event')
+    @pyitt_native_patch('StringHandle')
+    def test_event_creation_for_method(self, event_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        class MyClass:
+            @ittapi.event
+            def my_method(self):
+                pass  # pragma: no cover
+
+        event_class_mock.assert_called_once_with(f'{MyClass.my_method.__qualname__}')
+
+
+class EventPropertiesTest(TestCase):
+    @pyitt_native_patch('Event')
+    @pyitt_native_patch('StringHandle')
+    def test_event_properties(self, event_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        class CallableClass:
+            def __call__(self, *args, **kwargs):
+                pass  # pragma: no cover
+
+        event = ittapi.event(CallableClass())
+
+        expected_name = f'{CallableClass.__qualname__}.__call__'
+        event_class_mock.assert_called_once_with(expected_name)
+
+        self.assertEqual(event.name(), expected_name)
+
+        self.assertEqual(str(event), expected_name)
+        self.assertEqual(repr(event), f'{event.__class__.__qualname__}(\'{expected_name}\')')
+
+
+class EventExecutionTests(TestCase):
+    @pyitt_native_patch('Event')
+    @pyitt_native_patch('StringHandle')
+    def test_event_for_function(self, event_class_mock, string_handle_class_mock):
+        string_handle_class_mock.return_value = 'string_handle'
+
+        @ittapi.event
+        def my_function():
+            return 42
+
+        string_handle_class_mock.assert_called_once_with(my_function.__qualname__)
+        event_class_mock.assert_called_once_with(string_handle_class_mock.return_value)
+
+        self.assertEqual(my_function(), 42)
+
+        expected_calls = [call().begin(),
+                          call().end()]
+        event_class_mock.assert_has_calls(expected_calls)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_id.py
+++ b/tests/unit/compatibility_layers/ittapi/test_id.py
@@ -1,0 +1,22 @@
+from unittest import main as unittest_main, TestCase
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class IdTests(TestCase):
+    @pyitt_native_patch('Id')
+    def test_id_call(self, id_class_mock):
+        domain = 'my domain'
+        ittapi.id(domain)
+        id_class_mock.assert_called_once_with(domain)
+
+    @pyitt_native_patch('Id')
+    def test_id_creation(self, id_class_mock):
+        domain = 'my domain'
+        ittapi.Id(domain)
+        id_class_mock.assert_called_once_with(domain)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_pt_region.py
+++ b/tests/unit/compatibility_layers/ittapi/test_pt_region.py
@@ -1,0 +1,87 @@
+from inspect import stack
+from os.path import basename
+from unittest import main as unittest_main, TestCase
+from unittest.mock import call
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class PTRegionCreationTests(TestCase):
+    @pyitt_native_patch('PTRegion')
+    @pyitt_native_patch('StringHandle')
+    def test_pt_region_creation_with_default_constructor(self, pt_region_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        region = ittapi.pt_region()
+        caller = stack()[0]
+        expected_name = f'{basename(caller.filename)}:{caller.lineno-1}'
+
+        pt_region_class_mock.assert_not_called()
+
+        region.begin()
+
+        pt_region_class_mock.assert_called_once_with(expected_name)
+        self.assertEqual(region.name(), expected_name)
+
+    @pyitt_native_patch('PTRegion')
+    @pyitt_native_patch('StringHandle')
+    def test_pt_region_creation_as_decorator_for_function(self, pt_region_class_mock, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        @ittapi.pt_region
+        def my_function():
+            pass  # pragma: no cover
+
+        pt_region_class_mock.assert_called_once_with(my_function.__qualname__)
+
+    @pyitt_native_patch('PTRegion')
+    @pyitt_native_patch('StringHandle')
+    def test_pt_region_creation_as_decorator_with_name_for_function(self, pt_region_class_mock,
+                                                                    string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        @ittapi.pt_region('my function')
+        def my_function():
+            pass  # pragma: no cover
+
+        pt_region_class_mock.assert_called_once_with('my function')
+
+
+class PTRegionPropertiesTest(TestCase):
+    @pyitt_native_patch('StringHandle')
+    def test_pt_region_properties(self, string_handle_class_mock):
+        string_handle_class_mock.side_effect = lambda x: x
+
+        name = 'my pt region'
+        region = ittapi.pt_region(name)
+
+        self.assertIs(region.get_pt_region(), region)
+        self.assertEqual(region.name(), name)
+
+        self.assertEqual(str(region), name)
+        self.assertEqual(repr(region), f'{region.__class__.__name__}(\'{name}\')')
+
+
+class PTRegionExecutionTests(TestCase):
+    @pyitt_native_patch('PTRegion')
+    @pyitt_native_patch('StringHandle')
+    def test_pt_region_for_function(self, pt_region_class_mock, string_handle_class_mock):
+        string_handle_class_mock.return_value = 'string_handle'
+
+        @ittapi.pt_region
+        def my_function():
+            return 42
+
+        string_handle_class_mock.assert_called_once_with(my_function.__qualname__)
+        pt_region_class_mock.assert_called_once_with(string_handle_class_mock.return_value)
+
+        self.assertEqual(my_function(), 42)
+
+        expected_calls = [call().begin(),
+                          call().end()]
+        pt_region_class_mock.assert_has_calls(expected_calls)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_string_handle.py
+++ b/tests/unit/compatibility_layers/ittapi/test_string_handle.py
@@ -1,0 +1,22 @@
+from unittest import main as unittest_main, TestCase
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class StringHandleTests(TestCase):
+    @pyitt_native_patch('StringHandle')
+    def test_string_handle_call(self, string_handle_class_mock):
+        s = 'my string'
+        ittapi.string_handle(s)
+        string_handle_class_mock.assert_called_once_with(s)
+
+    @pyitt_native_patch('StringHandle')
+    def test_string_handle_creation(self, string_handle_class_mock):
+        s = 'my string'
+        ittapi.StringHandle(s)
+        string_handle_class_mock.assert_called_once_with(s)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_task.py
+++ b/tests/unit/compatibility_layers/ittapi/test_task.py
@@ -1,0 +1,197 @@
+from inspect import stack
+from os.path import basename
+from unittest import main as unittest_main, TestCase
+from unittest.mock import call
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class TaskCreationTests(TestCase):
+    @pyitt_native_patch('Domain')
+    @pyitt_native_patch('StringHandle')
+    @pyitt_native_patch('Id')
+    def test_task_creation_with_default_constructor(self, domain_class_mock, string_handle_class_mock, id_class_mock):
+        domain_class_mock.return_value = 'pyitt'
+        string_handle_class_mock.side_effect = lambda x: x
+        id_class_mock.return_value = 1
+
+        task = ittapi.task()
+        caller = stack()[0]
+        expected_name = f'{basename(caller.filename)}:{caller.lineno-1}'
+
+        string_handle_class_mock.assert_called_once_with(expected_name)
+        domain_class_mock.assert_called_once_with(None)
+
+        self.assertIsInstance(task, ittapi.NestedTask)
+        self.assertEqual(task.name(), expected_name)
+        self.assertEqual(task.domain(), domain_class_mock.return_value)
+        self.assertEqual(task.id(), id_class_mock.return_value)
+        self.assertIsNone(task.parent_id())
+
+    @pyitt_native_patch('StringHandle')
+    def test_task_creation_as_decorator_for_function(self, string_handle_class_mock):
+        @ittapi.task
+        def my_function():
+            pass  # pragma: no cover
+
+        string_handle_class_mock.assert_called_once_with(my_function.__qualname__)
+
+    @pyitt_native_patch('StringHandle')
+    def test_task_creation_as_decorator_with_name_for_function(self, string_handle_class_mock):
+        @ittapi.task('my function')
+        def my_function():
+            pass  # pragma: no cover
+
+        string_handle_class_mock.assert_called_once_with('my function')
+
+    def test_task_creation_overlapped_task(self):
+        task = ittapi.task(overlapped=True)
+        self.assertIsInstance(task, ittapi.OverlappedTask)
+
+
+class TaskPropertiesTest(TestCase):
+    @pyitt_native_patch('Domain')
+    @pyitt_native_patch('Id')
+    @pyitt_native_patch('StringHandle')
+    def test_task_properties(self, domain_class_mock, id_class_mock, string_handle_class_mock):
+        domain_class_mock.side_effect = lambda x: x
+        string_handle_class_mock.side_effect = lambda x: x
+        id_class_mock.return_value = lambda x: x
+
+        class CallableClass:
+            def __call__(self, *args, **kwargs):
+                pass  # pragma: no cover
+
+        domain_name = 'my domain'
+        task_id = 2
+        parent_id = 1
+        task = ittapi.task(CallableClass(), domain=domain_name, id=task_id, parent=parent_id)
+
+        expected_name = f'{CallableClass.__qualname__}.__call__'
+        string_handle_class_mock.assert_called_once_with(expected_name)
+
+        self.assertEqual(task.name(), expected_name)
+        self.assertEqual(task.domain(), domain_name)
+        self.assertEqual(task.id(), task_id)
+        self.assertEqual(task.parent_id(), parent_id)
+
+        self.assertEqual(str(task), f"{{ name: '{str(expected_name)}', domain: '{str(domain_name)}',"
+                                    f" id: {str(task_id)}, parent_id: {str(parent_id)} }}")
+
+        self.assertEqual(repr(task), f'{task.__class__.__qualname__}({repr(expected_name)}, {repr(domain_name)},'
+                                     f' {repr(task_id)}, {repr(parent_id)})')
+
+
+class TaskExecutionTests(TestCase):
+    @pyitt_native_patch('Domain')
+    @pyitt_native_patch('Id')
+    @pyitt_native_patch('StringHandle')
+    @pyitt_native_patch('task_begin')
+    @pyitt_native_patch('task_end')
+    def test_task_for_function(self, domain_class_mock, id_class_mock, string_handle_class_mock, task_begin_mock,
+                               task_end_mock):
+        domain_class_mock.return_value = 'domain_handle'
+        string_handle_class_mock.return_value = 'string_handle'
+        id_class_mock.return_value = 'id_handle'
+
+        @ittapi.task
+        def my_function():
+            return 42
+
+        domain_class_mock.assert_called_once_with(None)
+        string_handle_class_mock.assert_called_once_with(my_function.__qualname__)
+        id_class_mock.assert_called_once_with(domain_class_mock.return_value)
+
+        self.assertEqual(my_function(), 42)
+
+        task_begin_mock.assert_called_once_with(domain_class_mock.return_value, string_handle_class_mock.return_value,
+                                                id_class_mock.return_value, None)
+        task_end_mock.assert_called_once_with(domain_class_mock.return_value)
+
+
+class NestedTaskCreationTests(TestCase):
+    @pyitt_native_patch('Domain')
+    @pyitt_native_patch('StringHandle')
+    def test_task_creation_with_default_constructor(self, domain_class_mock, string_handle_class_mock):
+        ittapi.nested_task()
+        caller = stack()[0]
+        string_handle_class_mock.assert_called_once_with(f'{basename(caller.filename)}:{caller.lineno-1}')
+        domain_class_mock.assert_called_once_with(None)
+
+    @pyitt_native_patch('StringHandle')
+    def test_task_creation_with_first_named_argument(self, string_handle_class_mock):
+        name = 'my task'
+        ittapi.nested_task(task=name)
+        string_handle_class_mock.assert_called_once_with(name)
+
+
+class OverlappedTaskCreationTests(TestCase):
+    @pyitt_native_patch('Domain')
+    @pyitt_native_patch('StringHandle')
+    def test_task_creation_with_default_constructor(self, domain_class_mock, string_handle_class_mock):
+        ittapi.overlapped_task()
+        caller = stack()[0]
+        string_handle_class_mock.assert_called_once_with(f'{basename(caller.filename)}:{caller.lineno-1}')
+        domain_class_mock.assert_called_once_with(None)
+
+    @pyitt_native_patch('StringHandle')
+    def test_task_creation_with_first_named_argument(self, string_handle_class_mock):
+        name = 'my task'
+        ittapi.overlapped_task(task=name)
+        string_handle_class_mock.assert_called_once_with(name)
+
+
+class OverlappedTaskExecution(TestCase):
+    @pyitt_native_patch('Domain')
+    @pyitt_native_patch('Id')
+    @pyitt_native_patch('StringHandle')
+    @pyitt_native_patch('task_begin_overlapped')
+    @pyitt_native_patch('task_end_overlapped')
+    def test_overlapped_tasks(self, domain_class_mock, id_class_mock, string_handle_class_mock,
+                              task_begin_overlapped_mock, task_end_overlapped_mock):
+        domain_class_mock.return_value = 'domain_handle'
+        string_handle_class_mock.side_effect = lambda x: x
+
+        id_value = 0
+
+        def id_generator(*args, **kwargs):  # pylint: disable=W0613
+            nonlocal id_value
+            id_value += 1
+            return id_value
+
+        id_class_mock.side_effect = id_generator
+
+        overlapped_task_1_name = 'overlapped task 1'
+        overlapped_task_2_name = 'overlapped task 2'
+
+        overlapped_task_1 = ittapi.overlapped_task(overlapped_task_1_name)
+        overlapped_task_1.begin()
+
+        overlapped_task_2 = ittapi.overlapped_task(overlapped_task_2_name)
+        overlapped_task_2.begin()
+
+        overlapped_task_1.end()
+        overlapped_task_2.end()
+
+        expected_calls = [
+            call(overlapped_task_1_name),
+            call(overlapped_task_2_name)
+        ]
+        string_handle_class_mock.assert_has_calls(expected_calls)
+
+        expected_calls = [
+            call(domain_class_mock.return_value, overlapped_task_1_name, 1, None),
+            call(domain_class_mock.return_value, overlapped_task_2_name, 2, None)
+        ]
+        task_begin_overlapped_mock.assert_has_calls(expected_calls)
+
+        expected_calls = [
+            call(domain_class_mock.return_value, 1),
+            call(domain_class_mock.return_value, 2)
+        ]
+        task_end_overlapped_mock.assert_has_calls(expected_calls)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover

--- a/tests/unit/compatibility_layers/ittapi/test_thread_naming.py
+++ b/tests/unit/compatibility_layers/ittapi/test_thread_naming.py
@@ -1,0 +1,16 @@
+from unittest import main as unittest_main, TestCase
+
+from ...pyitt_native_mock import patch as pyitt_native_patch
+import pyitt.compatibility_layers.ittapi as ittapi  # pylint: disable=C0411
+
+
+class ThreadNamingTests(TestCase):
+    @pyitt_native_patch('thread_set_name')
+    def test_string_handle_call(self, thread_set_name_mock):
+        name = 'my thread'
+        ittapi.thread_set_name(name)
+        thread_set_name_mock.assert_called_once_with(name)
+
+
+if __name__ == '__main__':
+    unittest_main()  # pragma: no cover


### PR DESCRIPTION
Add `pyitt.compatibility_layers.ittapi` that implements most of ittapi Python binding public API.