### PR TITLE
Move the list of dependencies to requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install build coverage gcovr flake8 pylint diff-cover
+        python -m pip install -r requirements.txt
     - name: Lint with pylint the code of the package
       run: |
         pylint --max-line-length=120 --disable=E0401,E0611,W0621,W0622 "*.py" "pyitt/*.py"
@@ -101,7 +101,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install build coverage flake8 pylint diff-cover
+        python -m pip install -r requirements.txt
     - name: Lint with pylint the code of the package
       run: |
         pylint --max-line-length=120 --disable=E0401,E0611,W0621,W0622 "*.py" "pyitt/*.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+build
+coverage
+diff-cover
+flake8
+pylint
+
+gcovr; sys_platform == 'linux'


### PR DESCRIPTION
To simplify the preparation of the environment for the development, move the dependencies to requirements.txt.