### PR TITLE
Disable Dependabot for git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
-  - package-ecosystem: gitsubmodule
-    directory: /
-    schedule:
-      interval: weekly


### PR DESCRIPTION
Dependabot always updates the git submodule to the latest commit in the branch, but instead of it, the latest release should be used.