### PR TITLE
Disable R0917 pylint check for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         pylint --max-line-length=120 --disable=E0401,E0611,W0621,W0622 "*.py" "pyitt/*.py"
     - name: Lint with pylint the code of tests and samples
       run: |
-        pylint --max-line-length=120 --disable=E0401,E0611,C0114,C0115,C0116,R0801,R0903,R0904,R0913 "tests/*/*.py" "samples/*.py"
+        pylint --max-line-length=120 --disable=E0401,E0611,C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0917 "tests/*/*.py" "samples/*.py"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -119,7 +119,7 @@ jobs:
         pylint --max-line-length=120 --disable=E0401,E0611,W0621,W0622 "*.py" "pyitt/*.py"
     - name: Lint with pylint the code of tests and samples
       run: |
-        pylint --max-line-length=120 --disable=E0401,E0611,C0114,C0115,C0116,R0801,R0903,R0904,R0913 "tests/*/*.py" "samples/*.py"
+        pylint --max-line-length=120 --disable=E0401,E0611,C0114,C0115,C0116,R0801,R0903,R0904,R0913,R0917 "tests/*/*.py" "samples/*.py"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Disable R0917 "Too many positional arguments" for the tests because the number of the arguments is determined by how many mock objects are used in a specific test case.