### PR TITLE
Split a list of necessary packages into two files

### DIFF
--- a/requirements-locked.txt
+++ b/requirements-locked.txt
@@ -1,0 +1,7 @@
+# This file contains a list of dependencies with fixed versions that should not be automatically updated.
+# Build dependencies
+setuptools==75.3.0; python_version == '3.8'
+
+# Dev dependencies
+coverage==7.6.1; python_version == '3.8'
+pylint==3.2.7; python_version == '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
+# Include the file with the list of dependencies with fixed versions that should not be automatically updated.
+-r requirements-locked.txt
+
+# Build dependencies
 build==1.2.2
-coverage==7.6.1; python_version == '3.8'
-coverage==7.6.9; python_version >= '3.9'
-flake8==7.1.1
-pylint==3.2.7; python_version == '3.8'
-pylint==3.3.3; python_version >= '3.9'
-setuptools==75.3.0; python_version == '3.8'
 setuptools==75.6.0; python_version >= '3.9'
 
+# Dev dependencies
+coverage==7.6.9; python_version >= '3.9'
 gcovr==8.2; sys_platform == 'linux'
+flake8==7.1.1
+pylint==3.3.3; python_version >= '3.9'


### PR DESCRIPTION
Some of the required packages should not be automatically updated, because they are the latest for Python 3.8 and will not be updated in the future.