### PR TITLE
Move requirements for Python 3.8 to separate file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
       with:
         allow-prereleases: true
         python-version: ${{matrix.python-version}}
-    - name: Install dependencies
+    - name: Install dependencies for Python 3.8
+      if: ${{matrix.python-version}} == '3.8'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-3.8.txt
+    - name: Install dependencies for Python
+      if: ${{matrix.python-version}} != '3.8'
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
@@ -95,7 +101,13 @@ jobs:
       with:
         allow-prereleases: true
         python-version: ${{matrix.python-version}}
-    - name: Install dependencies
+    - name: Install dependencies for Python 3.8
+      if: ${{matrix.python-version}} == '3.8'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-3.8.txt
+    - name: Install dependencies for Python
+      if: ${{matrix.python-version}} != '3.8'
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,10 +13,17 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install dependencies
+      - name: Install dependencies for Python 3.8
+        if: ${{matrix.python-version}} == '3.8'
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build
+          python -m pip install -r requirements-3.8.txt
+
+      - name: Install dependencies for Python
+        if: ${{matrix.python-version}} != '3.8'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
 
       - name: Create source distribution
         run: python -m build --sdist

--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -1,0 +1,6 @@
+# Build dependencies
+build==1.2.2
+
+# Dev dependencies
+gcovr==8.2; sys_platform == 'linux'
+flake8==7.1.1

--- a/requirements-3.8.txt
+++ b/requirements-3.8.txt
@@ -1,4 +1,7 @@
 # This file contains a list of dependencies with fixed versions that should not be automatically updated.
+# Include common requirements
+-r common-requirements.txt
+
 # Build dependencies
 setuptools==75.3.0; python_version == '3.8'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
-# Include the file with the list of dependencies with fixed versions that should not be automatically updated.
--r requirements.locked
+-r common-requirements.txt
 
 # Build dependencies
-build==1.2.2
 setuptools==75.6.0; python_version >= '3.9'
 
 # Dev dependencies
 coverage==7.6.9; python_version >= '3.9'
-gcovr==8.2; sys_platform == 'linux'
-flake8==7.1.1
 pylint==3.3.3; python_version >= '3.9'


### PR DESCRIPTION
Dependabot does not take into account the python version that is specified in requirements.txt file. Therefore, it is necessary to separate the dependencies for different python versions to avoid the issue with updating the dependencies when new package version is not available for old python version.