### PR TITLE
Marks a line that is not reachable with 'no cover'

### DIFF
--- a/pyitt/_named_region.py
+++ b/pyitt/_named_region.py
@@ -160,7 +160,7 @@ class _NamedRegion(_Region):
             # PEP 3155 (Python 3.3) introduces __qualname__ on class objects
             return f'{func.__class__.__qualname__}.__call__'
 
-        raise ValueError('Cannot get the name for the code region.')
+        raise ValueError('Cannot get the name for the code region.')  # pragma: no cover
 
     @staticmethod
     def __to_string_handle(s):


### PR DESCRIPTION
All supported Python versions cannot reach the marked line. Therefore, it cannot be covered by a test.