### PR TITLE
Add integration tests for Event and PTRegion

### DIFF
--- a/tests/integration/test_event.py
+++ b/tests/integration/test_event.py
@@ -71,11 +71,35 @@ class EventTests(TestCase):
 
         self.assertIsNone(event.begin())
 
+    def test_event_begin_for_non_event_object(self):
+        with self.assertRaises(TypeError) as context:
+            Event.begin(None)  # pylint: disable=C2801
+
+        if python_implementation() == 'PyPy':
+            exception_str = f"The passed object is not a valid instance of pyitt.native.{Event.__name__} type."
+        else:
+            exception_str = (f"descriptor 'begin' for 'pyitt.native.{Event.__name__}' objects doesn't apply to a"
+                             f" 'NoneType' object")
+
+        self.assertEqual(str(context.exception), exception_str)
+
     def test_event_end(self):
         event_name = 'my event'
         event = Event(event_name)
 
         self.assertIsNone(event.end())
+
+    def test_event_end_for_non_event_object(self):
+        with self.assertRaises(TypeError) as context:
+            Event.end(None)  # pylint: disable=C2801
+
+        if python_implementation() == 'PyPy':
+            exception_str = f"The passed object is not a valid instance of pyitt.native.{Event.__name__} type."
+        else:
+            exception_str = (f"descriptor 'end' for 'pyitt.native.{Event.__name__}' objects doesn't apply to a"
+                             f" 'NoneType' object")
+
+        self.assertEqual(str(context.exception), exception_str)
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_pt_region.py
+++ b/tests/integration/test_pt_region.py
@@ -69,12 +69,35 @@ class PTRegionTests(TestCase):
 
         self.assertIsNone(region.begin())
 
+    def test_pt_region_begin_for_non_pt_region_object(self):
+        with self.assertRaises(TypeError) as context:
+            PTRegion.begin(None)  # pylint: disable=C2801
+
+        if python_implementation() == 'PyPy':
+            exception_str = f"The passed object is not a valid instance of pyitt.native.{PTRegion.__name__} type."
+        else:
+            exception_str = (f"descriptor 'begin' for 'pyitt.native.{PTRegion.__name__}' objects doesn't apply to a"
+                             f" 'NoneType' object")
+
+        self.assertEqual(str(context.exception), exception_str)
+
     def test_pt_region_end(self):
         region_name = 'my region'
         region = PTRegion(region_name)
 
         self.assertIsNone(region.end())
 
+    def test_pt_region_end_for_non_pt_region_object(self):
+        with self.assertRaises(TypeError) as context:
+            PTRegion.end(None)  # pylint: disable=C2801
+
+        if python_implementation() == 'PyPy':
+            exception_str = f"The passed object is not a valid instance of pyitt.native.{PTRegion.__name__} type."
+        else:
+            exception_str = (f"descriptor 'end' for 'pyitt.native.{PTRegion.__name__}' objects doesn't apply to a"
+                             f" 'NoneType' object")
+
+        self.assertEqual(str(context.exception), exception_str)
 
 if __name__ == '__main__':
     unittest_main()

--- a/tests/integration/test_pt_region.py
+++ b/tests/integration/test_pt_region.py
@@ -99,5 +99,6 @@ class PTRegionTests(TestCase):
 
         self.assertEqual(str(context.exception), exception_str)
 
+
 if __name__ == '__main__':
     unittest_main()


### PR DESCRIPTION
Add integration tests for the Event and PTRegion classes to check cases when the begin()/end() methods are called for objects of different classes.