### PR TITLE
Exclude Python 3.13.4 from CI workflow on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         # If the list of python versions is changed, please make sure that
         # `after_n_builds` flag in codecov.yml is updated accordingly
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10", "pypy3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "<3.13.4 || >3.13.4", "pypy3.9", "pypy3.10", "pypy3.11"]
     steps:
     - name: Checkout the code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Python 3.13.4 introduces a regression that breaks the build of native modules for non-threaded version. See
https://github.com/python/cpython/issues/135151 for details.