### PR TITLE
Fix deprecation warning from setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ description = "Python bindings to Intel Instrumentation and Tracing Technology (
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
-    "License :: OSI Approved :: BSD License",
     "Operating System :: Microsoft :: Windows",
 	"Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Remove license classifier, see https://peps.python.org/pep-0639/ for details.