### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directories: [".github/workflows", ".github/actions/**"]
     schedule:
-      interval: daily
+      interval: "daily"
     assignees: ["esuldin"]
-  - package-ecosystem: pip
-    directory: /
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
     assignees: ["esuldin"]


### PR DESCRIPTION
Configure Dependabot to monitor and update GitHub Actions dependencies in the repository.