### PR TITLE
Update version to 1.7.6

### DIFF
--- a/pyitt.native/pyitt_exec.cpp
+++ b/pyitt.native/pyitt_exec.cpp
@@ -45,8 +45,8 @@ static int exec_pyitt_module(PyObject* module)
     PyModule_AddFunctions(module, pyitt_functions);
 
     PyModule_AddStringConstant(module, "__author__", "Egor Suldin");
-    PyModule_AddStringConstant(module, "__version__", "1.7.5");
-    PyModule_AddIntConstant(module, "year", 2024);
+    PyModule_AddStringConstant(module, "__version__", "1.7.6");
+    PyModule_AddIntConstant(module, "year", 2026);
 
     return 0;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyitt"
-version = "1.7.5"
+version = "1.7.6"
 authors = [
   { name="Egor Suldin", email="rd3tap@yandex.ru" },
 ]


### PR DESCRIPTION
* Bump ittapi from 3.25.3 to 3.27.0
* Remove support for the `PYITT_ITT_API_SOURCE_DIR` environment variable, defaulting strictly to the local `ittapi` directory.